### PR TITLE
Pre-commit hook suggestion

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,7 @@
+#Uncompress set/s
+find ../../ -name \*.als | while read set
+do
+	gunzip -qS .${set##*.} "$set" &&
+	mv "${set%.*}" "$set"
+	git add .
+done


### PR DESCRIPTION
By moving this pre-commit file to the hidden .git/hooks folder, and setting it executable (chmod 755 pre-commit), every time you perform a commit the ALS project will be automatically uncompressed/renamed for you.
On GIT command line this happens when you invoke the "git commit" commant, on Tower it actually happens after you perform the commit, since the commit message composition window is Tower-native and the actual commit is performed after you press the Commit button.
It's an alternative to your solution for those who want to automate things even more.
I used your uncompress script for this, adding an additional "git add ." at the end to re-stage the uncompressed project file.
Hope you'll find it useful!
