### PR TITLE
Feature/pre commit hook

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,7 +1,13 @@
-#Uncompress set/s
-find . -name \*.als | while read set
+#!/bin/sh
+# Get a list of project files which ARE actually in the commit
+git diff --cached --name-only --diff-filter=ACM | grep .als | while read set
 do
-	gunzip -qS .${set##*.} "$set" &&
-	mv "${set%.*}" "$set"
-	git add "$set"
+	# uncompress just GZip files (aka the nominal Live ALS project files)
+	# if the project is already uncompressed, it'll just skip this part
+	if file --mime-type "$set" | grep -q gzip$; then
+		gunzip -qS .${set##*.} "$set" &&
+		mv "${set%.*}" "$set"
+		# stage back the ALS project since we modified it
+		git add "$set"
+	fi
 done

--- a/pre-commit
+++ b/pre-commit
@@ -1,7 +1,7 @@
 #Uncompress set/s
-find ../../ -name \*.als | while read set
+find . -name \*.als | while read set
 do
 	gunzip -qS .${set##*.} "$set" &&
 	mv "${set%.*}" "$set"
-	git add .
+	git add "$set"
 done

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,7 @@
+#Uncompress set/s
+find ../../ -name \*.als | while read set
+do
+	gunzip -qS .${set##*.} "$set" &&
+	mv "${set%.*}" "$set"
+	git add .
+done


### PR DESCRIPTION
This fixes my previous patch-1 fork.

By moving this pre-commit file to the hidden .git/hooks folder, and setting it executable (chmod 755 pre-commit), every time you perform a commit the ALS project will be automatically uncompressed/renamed for you.
On GIT command line this happens when you invoke the "git commit" commant, on Tower it actually happens after you perform the commit, since the commit message composition window is Tower-native and the actual commit is performed after you press the Commit button.
It's an alternative to your solution for those who want to automate things even more.
I used your uncompress script for this, adding an additional "git add ." at the end to re-stage the uncompressed project file.
Hope you'll find it useful!
